### PR TITLE
Added Fedora dependencies to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ build/
 .kdev4/
 CMakeLists.txt.user
 *.log
+*~
+*.swp
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ make install # as root
 ##### Fedora
 Requires [RPMFusion](https://rpmfusion.org/Configuration)
 ```
-sudo dnf install boost-devel boost-static openssl-devel openssl-static mpv-libs-devel log4cplus-devel uchardet-devel file-devel libcdio-devel libcdio-paranoia-devel alsa-lib-devel mesa-libEGL-devel enca-devel mesa-libgdm-devel jack-audio-connnection-kit-devel ffmpeg-devel libbluray-devel libass-devel mesa-libwayland-egl-devel libguess-devel libvdpau-devel libva-devel libXrandr-devel rubberband-devel libXinerama-devel SDL2-devel pulseaudio-libs-devel libsmbclient-devel libwayland-cursor-devel libv4l-devel libXScrnSaver-devel libXv-devel libxkbcommon-devel
+sudo dnf install boost-devel boost-static openssl-devel \
+openssl-static mpv-libs-devel log4cplus-devel uchardet-devel \
+file-devel libcdio-devel libcdio-paranoia-devel alsa-lib-devel \
+mesa-libEGL-devel enca-devel mesa-libgdm-devel \
+jack-audio-connnection-kit-devel \
+ffmpeg-devel libbluray-devel libass-devel mesa-libwayland-egl-devel \
+libguess-devel libvdpau-devel libva-devel libXrandr-devel \
+rubberband-devel libXinerama-devel SDL2-devel pulseaudio-libs-devel \
+libsmbclient-devel libwayland-cursor-devel libv4l-devel \
+libXScrnSaver-devel libXv-devel libxkbcommon-devel
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 WPlayer is a media player (based on mpv) that can be controlled from a web interface.
 
-To build:
+## Build
 
-- git clone ....
-- cd wplayer
-- mkdir build
-- cmake ../
-- make
-- make install (as root)
+```sh
+git clone ...
+mkdir wplayer/build && cd wplayer/build
+cmake ../
+make
+make install # as root
+```
+
+### Dependencies
+
+##### Fedora
+Requires [RPMFusion](https://rpmfusion.org/Configuration)
+```
+sudo dnf install boost-devel boost-static openssl-devel openssl-static mpv-libs-devel log4cplus-devel uchardet-devel file-devel libcdio-devel libcdio-paranoia-devel alsa-lib-devel mesa-libEGL-devel enca-devel mesa-libgdm-devel jack-audio-connnection-kit-devel ffmpeg-devel libbluray-devel libass-devel mesa-libwayland-egl-devel libguess-devel libvdpau-devel libva-devel libXrandr-devel rubberband-devel libXinerama-devel SDL2-devel pulseaudio-libs-devel libsmbclient-devel libwayland-cursor-devel libv4l-devel libXScrnSaver-devel libXv-devel libxkbcommon-devel
+```
 
 
-To start:
+## Start
 
  - Edit the conf file in the config folder
- - wplayer -c config/wplayer.conf
+ - `wplayer -c config/wplayer.conf`
  - Visit http://localhost:8080/


### PR DESCRIPTION
Added dependencies required to build wplayer on Fedora to README

There's [another change](https://github.com/hekar/wplayer/commit/9f0083fcb31e0ec17c252f62127b25c09c5294b2) required in `CMakeLists.txt` for the `mpv.pc` pkgconfig. I wasn't sure about how to add it without breaking other distributions. I think it's good enough that the issue is documented here. Someone that wants to build wplayer can figure out how to change that path for their own distribution.